### PR TITLE
Debug mailman

### DIFF
--- a/checkrestart/checkrestart.octopuce
+++ b/checkrestart/checkrestart.octopuce
@@ -199,6 +199,7 @@ if grep -q "/usr/bin/python2.7$" $TMPFILE2
 then
     FAIL2BANFOUND=0
     FAIL2BANPID=""
+    MAILMANFOUND=0
     for pid in $(grep "/usr/bin/python2.7$" $TMPFILE2|awk '{print $1}')
     do
 	# python launched as /usr/bin/fail2ban-server


### PR DESCRIPTION
Currently the script display an error when there is no mailman, because the `MAILMANFOUND` variable is not initialized:

```
./checkrestart.octopuce: ligne 224 : [:  : nombre entier attendu comme expression
```

This PR fixes this bug.
